### PR TITLE
change jifOutput->jifString in JifPage.svelte

### DIFF
--- a/src/lib/JifPage.svelte
+++ b/src/lib/JifPage.svelte
@@ -61,7 +61,7 @@
 	function save() {
 		if (!jif)
 			return;
-		var data = new Blob([jifOutput], {type: 'application/jif+json'});
+		var data = new Blob([jifString], {type: 'application/jif+json'});
 		var url = window.URL.createObjectURL(data);
 		savelink.href = url;
 	}


### PR DESCRIPTION
This is a very minor change that fixes a tiny bug that shows an error when you try to save from the Jif page.

> Uncaught ReferenceError: jifOutput is not defined
>     save JifPage.svelte:64
