### PR TITLE
Bug fixes: JIF page, propPermutation length, Movement curve scan

### DIFF
--- a/src/lib/JifPage.svelte
+++ b/src/lib/JifPage.svelte
@@ -83,8 +83,8 @@
 	.right  { grid-column:2 }
 	.input  { width:100%; height:30em }
 	.invalid { color:#dc3545 }
-	.error   { color:red }
-	.warnings { color:orange }
+	.error   { color:red; user-select:text; -webkit-user-select:text }
+	.warnings { color:orange; user-select:text; -webkit-user-select:text }
 	.animation-controls { display:flex; flex-flow:row wrap }
 </style>
 

--- a/src/lib/JifPage.svelte
+++ b/src/lib/JifPage.svelte
@@ -20,8 +20,16 @@
 	let warnings = [];
 	let animationSpeed = defaults.animationSpeed;
 
-	if (useLocalStorage)
-		jifString = localStorage.getItem('jif', null);
+	if (useLocalStorage) {
+		// getItem returns null when the key is unset (e.g. first visit, incognito,
+		// or after clearing site data). The old code assigned that null straight to
+		// jifString, so Jif.complete(null) threw ("Cannot read properties of null")
+		// and the page froze. Only override the default when a real value is stored.
+		// (The second `null` arg was also a no-op — getItem takes one argument.)
+		const stored = localStorage.getItem('jif');
+		if (stored !== null && stored !== '')
+			jifString = stored;
+	}
 
 	$: {
 		try {

--- a/src/lib/animation.mjs
+++ b/src/lib/animation.mjs
@@ -498,21 +498,29 @@ constructor(p)
 
 getCurveAndFraction(t)
 {
+	// Commit this.lastIndex (the search-start hint) only on a MATCH. The old code
+	// reassigned it every iteration, so `index = (lastIndex + i) % nCurves` used a
+	// lastIndex that grew within the loop and skipped curves: starting from
+	// lastIndex 0 with 6 curves it probed 0,1,3,0,4,3 — never 2 or 5. The
+	// period-wrapping curve was among those skipped, so the prop/hand froze for that
+	// span and then snapped. Only advancing the hint on a hit keeps the scan honest.
 	for (let i = 0; i < this.nCurves; i++) {
 		const index = (this.lastIndex + i) % this.nCurves;
-		this.lastIndex = index;
 		const c = this.positionCurves[index];
 		const end = c.start + c.duration;
-		if (c.start <= t && t < end)
+		if (c.start <= t && t < end) {
+			this.lastIndex = index;
 			return {
 				curve: c,
 				fraction: (t - c.start) / c.duration,
 			};
-		else if (end > this.periodSeconds && t < (end % this.periodSeconds)) // wrap around period
+		} else if (end > this.periodSeconds && t < (end % this.periodSeconds)) { // wrap around period
+			this.lastIndex = index;
 			return {
 				curve: c,
 				fraction: (t - c.start + this.periodSeconds) / c.duration,
 			};
+		}
 	}
 	return undefined;
 }

--- a/src/lib/jif.mjs
+++ b/src/lib/jif.mjs
@@ -175,7 +175,7 @@ function _completeRepetition({ jif, warnings })
 				if (typeof rep.propPermutation != 'undefined')
 					warnings.push("repetition.propPermutation has unexpected type, setting to identity");
 				rep.propPermutation = defaultPropPermutation;
-			} else if (rep.propPermutation.length != jif.limbs.length) {
+			} else if (rep.propPermutation.length != jif.props.length) {
 				rep.propPermutation = defaultPropPermutation;
 				warnings.push("invalid size of repetition.propPermutation, setting to identity");
 			}


### PR DESCRIPTION
Four small, independent fixes (each its own commit, based on main):
1. jif-page: guard against null localStorage 'jif' on first load (page froze on first visit / incognito)
2. jif-page: make parse error/warning text selectable
3. jif: validate propPermutation length against props, not limbs
4. animation: only advance Movement.lastIndex on a match (the scan skipped curves → a prop/hand could freeze for a span)

Your test suite passes (35/35). Generated with Claude/Codex assistance; commits carry Co-authored-by: trailers.